### PR TITLE
encode: Ignore .log files in find_audio_files

### DIFF
--- a/encode_framework/encode/audio.py
+++ b/encode_framework/encode/audio.py
@@ -65,6 +65,9 @@ class _AudioEncoder(_BaseEncoder):
             for f in dgi_file.parent.glob(f"{dgi_file.stem}*.*"):
                 Log.debug(f"Checking the following file: \"{f.name}\"...", self.find_audio_files)
 
+                # explicitly ignore log file; audio.parse seems to count those for some reason?
+                if f.suffix == ".log": continue
+
                 try:
                     FileType.AUDIO.parse(f, func=self.find_audio_files)
                 except (AssertionError, ValueError):


### PR DESCRIPTION
`FileType.AUDIO.parse` seems to, at least sometimes, treat log files as audio files.

This is a hacky solution, and it would be better to fix the logic in `AUDIO.parse` instead. However, a log file will always be present here, and it will never have audio, so this method of dealing with it at least should not pose more problems.